### PR TITLE
Include credentials while making fetch calls

### DIFF
--- a/src/components/services/AdGuardHome.vue
+++ b/src/components/services/AdGuardHome.vue
@@ -52,7 +52,7 @@ export default {
   methods: {
     fetchStatus: async function () {
       this.status = await fetch(`${this.item.url}/control/status`{
-        credentials: 'include',
+        credentials: "include",
       }).then(
         (response) => response.json()
       );

--- a/src/components/services/AdGuardHome.vue
+++ b/src/components/services/AdGuardHome.vue
@@ -51,7 +51,7 @@ export default {
   },
   methods: {
     fetchStatus: async function () {
-      this.status = await fetch(`${this.item.url}/control/status`{
+      this.status = await fetch(`${this.item.url}/control/status`, {
         credentials: "include",
       }).then(
         (response) => response.json()

--- a/src/components/services/AdGuardHome.vue
+++ b/src/components/services/AdGuardHome.vue
@@ -51,7 +51,9 @@ export default {
   },
   methods: {
     fetchStatus: async function () {
-      this.status = await fetch(`${this.item.url}/control/status`).then(
+      this.status = await fetch(`${this.item.url}/control/status`{
+        credentials: 'include',
+      }).then(
         (response) => response.json()
       );
     },

--- a/src/components/services/PaperlessNG.vue
+++ b/src/components/services/PaperlessNG.vue
@@ -59,7 +59,7 @@ export default {
       }
       const url = `${this.item.url}/api/documents/`;
       this.api = await fetch(url, {
-        credentials: 'include',
+        credentials: "include",
         headers: {
           Authorization: "Token " + this.item.apikey,
         },

--- a/src/components/services/PaperlessNG.vue
+++ b/src/components/services/PaperlessNG.vue
@@ -59,6 +59,7 @@ export default {
       }
       const url = `${this.item.url}/api/documents/`;
       this.api = await fetch(url, {
+        credentials: 'include',
         headers: {
           Authorization: "Token " + this.item.apikey,
         },

--- a/src/components/services/PiHole.vue
+++ b/src/components/services/PiHole.vue
@@ -64,7 +64,7 @@ export default {
   methods: {
     fetchStatus: async function () {
       const url = `${this.item.url}/api.php`;
-      this.api = await fetch(url{
+      this.api = await fetch(url, {
         credentials: "include",
       })
         .then((response) => response.json())

--- a/src/components/services/PiHole.vue
+++ b/src/components/services/PiHole.vue
@@ -65,7 +65,7 @@ export default {
     fetchStatus: async function () {
       const url = `${this.item.url}/api.php`;
       this.api = await fetch(url{
-        credentials: 'include'
+        credentials: "include",
       })
         .then((response) => response.json())
         .catch((e) => console.log(e));

--- a/src/components/services/PiHole.vue
+++ b/src/components/services/PiHole.vue
@@ -64,7 +64,9 @@ export default {
   methods: {
     fetchStatus: async function () {
       const url = `${this.item.url}/api.php`;
-      this.api = await fetch(url)
+      this.api = await fetch(url{
+        credentials: 'include'
+      })
         .then((response) => response.json())
         .catch((e) => console.log(e));
     },

--- a/src/components/services/Ping.vue
+++ b/src/components/services/Ping.vue
@@ -50,7 +50,11 @@ export default {
   methods: {
     fetchStatus: async function () {
       const url = `${this.item.url}`;
-      fetch(url, { method: "HEAD", cache: "no-cache" })
+      fetch(url, {
+        method: "HEAD",
+        cache: "no-cache",
+        credentials: "include",
+      })
         .then((response) => {
           if (!response.ok) {
             throw Error(response.statusText);


### PR DESCRIPTION
## Description

When making `fetch` calls for data to populate special tiles like Pi-Hole, we should include any credentials stored as cookies for the domain. This enables support for multiple subdomains fronted by a single sign one auth provider. e.g. `homer.example.com` tries to reach out to get data from `pihole.example.com`, where both of these share a common auth provider. Without including credentials in the `fetch`, the call would fail as it would get redirected to `login.example.com`

Fixes # (issue): N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
