### PR TITLE
Add credentials: "include" back to Radarr`

### DIFF
--- a/src/components/services/Radarr.vue
+++ b/src/components/services/Radarr.vue
@@ -70,7 +70,9 @@ export default {
   },
   methods: {
     fetchConfig: function () {
-      fetch(`${this.item.url}/api/health?apikey=${this.item.apikey}`)
+      fetch(`${this.item.url}/api/health?apikey=${this.item.apikey}`, {
+        credentials: "include",
+      })
         .then((response) => {
           if (response.status != 200) {
             throw new Error(response.statusText);
@@ -92,7 +94,9 @@ export default {
           console.error(e);
           this.serverError = true;
         });
-      fetch(`${this.item.url}/api/queue?apikey=${this.item.apikey}`)
+      fetch(`${this.item.url}/api/queue?apikey=${this.item.apikey}`, {
+        credentials: "include",
+      })
         .then((response) => {
           if (response.status != 200) {
             throw new Error(response.statusText);

--- a/src/components/services/Sonarr.vue
+++ b/src/components/services/Sonarr.vue
@@ -70,7 +70,9 @@ export default {
   },
   methods: {
     fetchConfig: function () {
-      fetch(`${this.item.url}/api/health?apikey=${this.item.apikey}`)
+      fetch(`${this.item.url}/api/health?apikey=${this.item.apikey}`, {
+        credentials: "include",
+      })
         .then((response) => {
           if (response.status != 200) {
             throw new Error(response.statusText);

--- a/src/components/services/Sonarr.vue
+++ b/src/components/services/Sonarr.vue
@@ -94,7 +94,9 @@ export default {
           console.error(e);
           this.serverError = true;
         });
-      fetch(`${this.item.url}/api/queue?apikey=${this.item.apikey}`)
+      fetch(`${this.item.url}/api/queue?apikey=${this.item.apikey}`, {
+        credentials: "include",
+      })
         .then((response) => {
           if (response.status != 200) {
             throw new Error(response.statusText);


### PR DESCRIPTION
## Description

`credentials: "include"` was mistakenly removed from the Sonarr and Radarr components [when migrating the API key from a header to a query param](https://github.com/bastienwirtz/homer/commit/25f99adc6c854f27dc1df4a88bf8da5b01812f46). This PR adds the `fetch` option back to support set ups with SSO providers like Authelia and others. Similar to [PR-258](https://github.com/bastienwirtz/homer/pull/258)

Fixes # (issue)
_Possibly_ https://github.com/bastienwirtz/homer/issues/251. That assumes they're running an SSO like Authelia, and the JSON parse data is because it's getting the login page HTML instead of the API JSON. Can't tell without more info on the Issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/bastienwirtz/homer/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. 
- [x] I have made corresponding changes the documentation (README.md).
- [x] I've checked my modifications for any breaking changes, especially in the `config.yml` file
